### PR TITLE
Update xtext-maven-plugin.version and emf.codegen.ecore.xtext.version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,11 +21,8 @@
         <eclipse.text.version>3.5.101</eclipse.text.version>
         <guava.version>20.0</guava.version>
         <!-- Plugin versions -->
-        <xtext-maven-plugin.version>2.15.0</xtext-maven-plugin.version>
-        <!-- Downgrade the codegen version to 1.2.0. For whatever reason xtext-maven-plugin -->
-        <!-- fails with 1.4.0 -->
-        <!-- Related issues: https://github.com/eclipse/xtext/issues/1233 -->
-        <emf.codegen.ecore.xtext.version>1.2.0</emf.codegen.ecore.xtext.version>
+        <xtext-maven-plugin.version>2.22.0</xtext-maven-plugin.version>
+        <emf.codegen.ecore.xtext.version>1.4.0</emf.codegen.ecore.xtext.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
Updated `xtext-maven-plugin.version` and `emf.codegen.ecore.xtext.version` from `2.15.0` and `1.2.0` to `2.22.0` and `1.4.0` respectively to solve the issue reported in https://github.com/xatkit-bot-platform/xatkit/issues/30 and https://github.com/xatkit-bot-platform/xatkit/pull/26#issuecomment-649517029. 
The issue is related to the build error: 
```
java.lang.SecurityException: class "org.eclipse.core.runtime.Plugin"'s signer information does not match signer information of other classes in the same package
	at java.lang.ClassLoader.checkCerts(ClassLoader.java:898)
	at java.lang.ClassLoader.preDefineClass(ClassLoader.java:668)
	at java.lang.ClassLoader.defineClass(ClassLoader.java:761)
	at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
	at java.net.URLClassLoader.defineClass(URLClassLoader.java:467)
	at java.net.URLClassLoader.access$100(URLClassLoader.java:73)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:368)
```
The problem occurs because of an upgrade in the Eclipse/Xtext dependencies using the same package resulting in a certificate conflict.
There was the following comment in the code: 
```
        <!-- Downgrade the codegen version to 1.2.0. For whatever reason xtext-maven-plugin -->
        <!-- fails with 1.4.0 -->
        <!-- Related issues: https://github.com/eclipse/xtext/issues/1233 -->
```
However upgrading to 1.4.0 didn't lead to any problem.